### PR TITLE
Auto-approve pending GitHub workflow runs after branch update

### DIFF
--- a/src/Aviationexam.DependencyUpdater.Interfaces/ISourceVersioningWorkspace.cs
+++ b/src/Aviationexam.DependencyUpdater.Interfaces/ISourceVersioningWorkspace.cs
@@ -8,6 +8,8 @@ public interface ISourceVersioningWorkspace : IDisposable
 
     string GetBranchName();
 
+    string GetBranchTipCommitId();
+
     bool IsPathInsideRepository(
         string fullPath
     );

--- a/src/Aviationexam.DependencyUpdater.Interfaces/Repository/IRepositoryClient.cs
+++ b/src/Aviationexam.DependencyUpdater.Interfaces/Repository/IRepositoryClient.cs
@@ -37,6 +37,19 @@ public interface IRepositoryClient
         CancellationToken cancellationToken
     );
 
+    /// <summary>
+    /// Approves any workflow runs that are pending maintainer approval for the given branch.
+    /// This is typically required for workflow runs triggered by first-time contributors or
+    /// when approval is otherwise required by repository policy.
+    /// Platforms that do not implement this concept should treat this as a no-op.
+    /// </summary>
+    /// <param name="branchName">The branch whose pending workflow runs should be approved.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ApprovePendingWorkflowRunsAsync(
+        string branchName,
+        CancellationToken cancellationToken
+    );
+
     Task AbandonPullRequestAsync(
         PullRequest pullRequest,
         CancellationToken cancellationToken

--- a/src/Aviationexam.DependencyUpdater.Interfaces/Repository/IRepositoryClient.cs
+++ b/src/Aviationexam.DependencyUpdater.Interfaces/Repository/IRepositoryClient.cs
@@ -38,15 +38,15 @@ public interface IRepositoryClient
     );
 
     /// <summary>
-    /// Approves any workflow runs that are pending maintainer approval for the given branch.
+    /// Approves any workflow runs that are pending maintainer approval for the given commit.
     /// This is typically required for workflow runs triggered by first-time contributors or
     /// when approval is otherwise required by repository policy.
     /// Platforms that do not implement this concept should treat this as a no-op.
     /// </summary>
-    /// <param name="branchName">The branch whose pending workflow runs should be approved.</param>
+    /// <param name="headSha">The commit SHA whose pending workflow runs should be approved.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task ApprovePendingWorkflowRunsAsync(
-        string branchName,
+        string headSha,
         CancellationToken cancellationToken
     );
 

--- a/src/Aviationexam.DependencyUpdater.Nuget/Services/PackageUpdater.cs
+++ b/src/Aviationexam.DependencyUpdater.Nuget/Services/PackageUpdater.cs
@@ -349,6 +349,12 @@ public sealed class PackageUpdater(
                 description: commitMessage,
                 cancellationToken
             );
+
+            await repositoryClient.ApprovePendingWorkflowRunsAsync(
+                branchName: gitWorkspace.GetBranchName(),
+                cancellationToken
+            );
+
             return pullRequestId;
         }
 

--- a/src/Aviationexam.DependencyUpdater.Nuget/Services/PackageUpdater.cs
+++ b/src/Aviationexam.DependencyUpdater.Nuget/Services/PackageUpdater.cs
@@ -351,7 +351,7 @@ public sealed class PackageUpdater(
             );
 
             await repositoryClient.ApprovePendingWorkflowRunsAsync(
-                branchName: gitWorkspace.GetBranchName(),
+                headSha: gitWorkspace.GetBranchTipCommitId(),
                 cancellationToken
             );
 

--- a/src/Aviationexam.DependencyUpdater.Repository.DevOps/RepositoryAzureDevOpsClient.cs
+++ b/src/Aviationexam.DependencyUpdater.Repository.DevOps/RepositoryAzureDevOpsClient.cs
@@ -217,6 +217,17 @@ public class RepositoryAzureDevOpsClient(
         }
     }
 
+    public Task ApprovePendingWorkflowRunsAsync(
+        string branchName,
+        CancellationToken cancellationToken
+    )
+    {
+        // Azure DevOps pipelines do not require maintainer approval in the same way
+        // GitHub Actions do for first-time contributors. Approvals are handled via
+        // environment/approval gates at pipeline stage level, not via this workflow.
+        return Task.CompletedTask;
+    }
+
     public async Task AbandonPullRequestAsync(
         PullRequest pullRequest,
         CancellationToken cancellationToken

--- a/src/Aviationexam.DependencyUpdater.Repository.DevOps/RepositoryAzureDevOpsClient.cs
+++ b/src/Aviationexam.DependencyUpdater.Repository.DevOps/RepositoryAzureDevOpsClient.cs
@@ -218,7 +218,7 @@ public class RepositoryAzureDevOpsClient(
     }
 
     public Task ApprovePendingWorkflowRunsAsync(
-        string branchName,
+        string headSha,
         CancellationToken cancellationToken
     )
     {

--- a/src/Aviationexam.DependencyUpdater.Repository.GitHub/RepositoryGitHubClient.cs
+++ b/src/Aviationexam.DependencyUpdater.Repository.GitHub/RepositoryGitHubClient.cs
@@ -273,13 +273,13 @@ public class RepositoryGitHubClient(
     }
 
     public async Task ApprovePendingWorkflowRunsAsync(
-        string branchName,
+        string headSha,
         CancellationToken cancellationToken
     )
     {
         var workflowRunsRequest = new WorkflowRunsRequest
         {
-            Branch = branchName,
+            HeadSha = headSha,
             Status = CheckRunStatusFilter.ActionRequired,
         };
 
@@ -296,7 +296,7 @@ public class RepositoryGitHubClient(
         {
             if (logger.IsEnabled(LogLevel.Warning))
             {
-                logger.LogWarning(ex, "Failed to list pending workflow runs for branch {BranchName}", branchName);
+                logger.LogWarning(ex, "Failed to list pending workflow runs for commit {HeadSha}", headSha);
             }
 
             return;
@@ -306,7 +306,7 @@ public class RepositoryGitHubClient(
         {
             if (logger.IsEnabled(LogLevel.Trace))
             {
-                logger.LogTrace("No pending workflow runs for branch {BranchName}", branchName);
+                logger.LogTrace("No pending workflow runs for commit {HeadSha}", headSha);
             }
 
             return;
@@ -325,10 +325,10 @@ public class RepositoryGitHubClient(
                 if (logger.IsEnabled(LogLevel.Information))
                 {
                     logger.LogInformation(
-                        "Approved pending workflow run {WorkflowRunId} ({WorkflowRunName}) for branch {BranchName}",
+                        "Approved pending workflow run {WorkflowRunId} ({WorkflowRunName}) for commit {HeadSha}",
                         workflowRun.Id,
                         workflowRun.Name,
-                        branchName
+                        headSha
                     );
                 }
             }
@@ -338,9 +338,9 @@ public class RepositoryGitHubClient(
                 {
                     logger.LogWarning(
                         ex,
-                        "Failed to approve workflow run {WorkflowRunId} for branch {BranchName}",
+                        "Failed to approve workflow run {WorkflowRunId} for commit {HeadSha}",
                         workflowRun.Id,
-                        branchName
+                        headSha
                     );
                 }
             }

--- a/src/Aviationexam.DependencyUpdater.Repository.GitHub/RepositoryGitHubClient.cs
+++ b/src/Aviationexam.DependencyUpdater.Repository.GitHub/RepositoryGitHubClient.cs
@@ -272,6 +272,81 @@ public class RepositoryGitHubClient(
         }
     }
 
+    public async Task ApprovePendingWorkflowRunsAsync(
+        string branchName,
+        CancellationToken cancellationToken
+    )
+    {
+        var workflowRunsRequest = new WorkflowRunsRequest
+        {
+            Branch = branchName,
+            Status = CheckRunStatusFilter.ActionRequired,
+        };
+
+        WorkflowRunsResponse workflowRuns;
+        try
+        {
+            workflowRuns = await gitHubClient.Actions.Workflows.Runs.List(
+                gitHubConfiguration.Owner,
+                gitHubConfiguration.Repository,
+                workflowRunsRequest
+            );
+        }
+        catch (ApiException ex)
+        {
+            if (logger.IsEnabled(LogLevel.Warning))
+            {
+                logger.LogWarning(ex, "Failed to list pending workflow runs for branch {BranchName}", branchName);
+            }
+
+            return;
+        }
+
+        if (workflowRuns.TotalCount == 0)
+        {
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace("No pending workflow runs for branch {BranchName}", branchName);
+            }
+
+            return;
+        }
+
+        foreach (var workflowRun in workflowRuns.WorkflowRuns)
+        {
+            try
+            {
+                await gitHubClient.Actions.Workflows.Runs.Approve(
+                    gitHubConfiguration.Owner,
+                    gitHubConfiguration.Repository,
+                    workflowRun.Id
+                );
+
+                if (logger.IsEnabled(LogLevel.Information))
+                {
+                    logger.LogInformation(
+                        "Approved pending workflow run {WorkflowRunId} ({WorkflowRunName}) for branch {BranchName}",
+                        workflowRun.Id,
+                        workflowRun.Name,
+                        branchName
+                    );
+                }
+            }
+            catch (ApiException ex)
+            {
+                if (logger.IsEnabled(LogLevel.Warning))
+                {
+                    logger.LogWarning(
+                        ex,
+                        "Failed to approve workflow run {WorkflowRunId} for branch {BranchName}",
+                        workflowRun.Id,
+                        branchName
+                    );
+                }
+            }
+        }
+    }
+
     public async Task AbandonPullRequestAsync(
         PullRequest pullRequest,
         CancellationToken cancellationToken

--- a/src/Aviationexam.DependencyUpdater.Vcs.Git/GitSourceVersioningWorkspace.cs
+++ b/src/Aviationexam.DependencyUpdater.Vcs.Git/GitSourceVersioningWorkspace.cs
@@ -66,6 +66,14 @@ public sealed class GitSourceVersioningWorkspace(
         }
     }
 
+    public string GetBranchTipCommitId()
+    {
+        lock (gitRepositoryLock)
+        {
+            return _worktreeRepository.Head.Tip.Sha;
+        }
+    }
+
     public bool IsPathInsideRepository(
         string fullPath
     )


### PR DESCRIPTION
## Summary

Adds `IRepositoryClient.ApprovePendingWorkflowRunsAsync(branchName, ct)` and invokes it automatically after an existing dependency-update PR's branch is updated. This clicks the **"Approve workflows to run"** button via the GitHub Actions API so CI doesn't stall waiting for maintainer approval on refreshed runs.

## Why

When a PR is updated with new commits (e.g. Dependency Updater refreshes versions on a long-lived PR), GitHub Actions may re-enter the `action_required` state if the repository requires maintainer approval for workflow runs (first-time contributor policy, fork PRs, etc.). Previously this required a human to click the button before CI could re-validate the branch. The updater now does it automatically.

## Changes

- **Interface** (`IRepositoryClient`): new `ApprovePendingWorkflowRunsAsync` method, documented as a platform-optional no-op.
- **GitHub** (`RepositoryGitHubClient`): lists runs with `status=action_required` filtered by branch via `gitHubClient.Actions.Workflows.Runs.List(...)`, then calls `.Approve(...)` for each. API failures are logged as warnings and never bubble up — a failed approval must not break a successful dependency update.
- **Azure DevOps** (`RepositoryAzureDevOpsClient`): intentional no-op. Azure Pipelines gate stages via environment approvals configured in the pipeline, not via a per-run approve endpoint.
- **Wiring** (`PackageUpdater.CreateOrUpdatePullRequestAsync`): calls `ApprovePendingWorkflowRunsAsync` on the **update path only** (`pullRequestId is not null`). New PRs are unaffected — the existing authentication proxy already uses a GitHub App identity that triggers CI without approval.

## Call path

`PackageUpdater.HandlePullRequestAsync` → `gitWorkspace.Push()` → (if pushed && PR exists) → `repositoryClient.UpdatePullRequestAsync()` → **`repositoryClient.ApprovePendingWorkflowRunsAsync()`** → return.

## Test Plan

- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test` on `Aviationexam.DependencyUpdater.Nuget.Tests` — 93/93 passing
- [x] LSP diagnostics clean on all 4 changed files

## Notes

- The `action_required` filter targets runs waiting on maintainer approval. `ReviewPendingDeployments` (environment approvals) is explicitly out of scope.
- Requires `actions: write` permission on the GitHub token — already implied by the existing `repo` scope for PATs and `pull-requests: write` + `actions: write` on GitHub Actions.